### PR TITLE
Fix default poster bugs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -160,8 +160,8 @@ savePosterButton.addEventListener('click', function () {
 makePosterButton.addEventListener('click', function(event) {
   event.preventDefault()
   makeMyPoster(titleInput, quoteInput, imageInput)
-  pushInputsToData(titleInput, quoteInput, imageInput)
   defaultEmptyFormPoster()
+  pushInputsToData(titleInput, quoteInput, imageInput)
   switchViews(mainPageView)
 })
 
@@ -182,9 +182,11 @@ function deletePoster(id) {
 }
 
 function pushInputsToData() {
-  titles.push(titleInput.value)
-  quotes.push(quoteInput.value) 
-  images.push(imageInput.value)
+  if (currentPoster.title !== 'Is this a poster?') {
+    titles.push(titleInput.value)
+    quotes.push(quoteInput.value) 
+    images.push(imageInput.value)
+  }
 }
 
 function switchViews(goToView) {
@@ -196,13 +198,13 @@ function switchViews(goToView) {
 function showSavedPosters() {
   savePosterGrid.innerHTML = ""
   for(var i = 0; i < savedPosters.length; i++) {
-  var showGridDisplay = 
-    `<article class="mini-poster" id="${savedPosters[i].id}"> 
-      <img src="${savedPosters[i].imageURL}" alt="mini nothin' to see here">
-      <h2>${savedPosters[i].title}</h2>
-      <h4>${savedPosters[i].quote}</h4> 
-    </article>`
-  savePosterGrid.innerHTML += showGridDisplay
+    var showGridDisplay = 
+      `<article class="mini-poster" id="${savedPosters[i].id}"> 
+        <img src="${savedPosters[i].imageURL}" alt="mini nothin' to see here">
+        <h2>${savedPosters[i].title}</h2>
+        <h4>${savedPosters[i].quote}</h4> 
+      </article>`
+    savePosterGrid.innerHTML += showGridDisplay
   }
 }
 
@@ -244,7 +246,7 @@ function makeMyPoster(titleInput, quoteInput, imageInput) {
 }
 
 function saveCurrentPoster() {
-  if (!savedPosters.includes(currentPoster)) {
+  if (!savedPosters.includes(currentPoster) && currentPoster.title !== 'Is this a poster?') {
     savedPosters.push(currentPoster)
   }
 }


### PR DESCRIPTION
Fixed bugs relating to the default form poster so that:

Default poster can't be added to savedPosters array. The way this was done, however, will also prevent all user posters that have the title 'Is this a poster?' from being saved as well.

Form inputs that are a part of an incomplete form will not be added to data model arrays if the default poster is displayed.

Rearranged eventListener function execution order so that pushInputsToData() will execute after the defaultEmptyFormPoster() has a chance to display default poster if necessary.
